### PR TITLE
Finished Save Functionality and Improved Variable Editor

### DIFF
--- a/core/src/main/kotlin/ksl/animation/builder/AnimationBuilder.kt
+++ b/core/src/main/kotlin/ksl/animation/builder/AnimationBuilder.kt
@@ -19,6 +19,10 @@ class AnimationBuilder(private val onObjectClick: (kslObject: KSLRenderable?) ->
     var snapToGrid = false
 
     init {
+        this.loadDefaultImage()
+    }
+
+    private fun loadDefaultImage() {
         try {
             val decodedBytes = Base64.getDecoder().decode(ResourceStates.DEFAULT_IMAGE)
             val pixmap = Pixmap(decodedBytes, 0, decodedBytes.size)
@@ -27,6 +31,14 @@ class AnimationBuilder(private val onObjectClick: (kslObject: KSLRenderable?) ->
         } catch (e: IllegalArgumentException) {
             println("Invalid Base64 string for image: DEFAULT")
         }
+    }
+
+    override fun resetScene() {
+        super.resetScene()
+        this.loadDefaultImage()
+        this.selectedObject = ""
+        this.snapToGrid = false
+        onObjectClick.invoke(null)
     }
 
     fun addObject(type: String) {

--- a/core/src/main/kotlin/ksl/animation/builder/AnimationBuilderScreen.kt
+++ b/core/src/main/kotlin/ksl/animation/builder/AnimationBuilderScreen.kt
@@ -34,7 +34,7 @@ class AnimationBuilderScreen(private val game: KtxGame<KtxScreen>) : KtxScreen, 
     private val objectEditor = ObjectEditorWindow()
     private val fileChooser = FileChooser(FileChooser.Mode.OPEN)
     private val saveFileChooser = FileChooser(FileChooser.Mode.SAVE)
-    private var animationBuilder = AnimationBuilder({ renderable -> objectEditor.showObject(renderable) })
+    private var animationBuilder = AnimationBuilder({ renderable -> objectEditor.showObject(renderable, stage) })
     private var controlPressed = false
     //Test
 

--- a/core/src/main/kotlin/ksl/animation/builder/AnimationBuilderScreen.kt
+++ b/core/src/main/kotlin/ksl/animation/builder/AnimationBuilderScreen.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Input
 import com.badlogic.gdx.InputAdapter
 import com.badlogic.gdx.InputMultiplexer
+import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.utils.viewport.ScreenViewport
 import com.kotcrab.vis.ui.VisUI
@@ -11,6 +12,10 @@ import com.kotcrab.vis.ui.widget.MenuBar
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.file.FileChooser
+import com.kotcrab.vis.ui.widget.file.FileChooser.DefaultFileIconProvider
+import com.kotcrab.vis.ui.widget.file.FileTypeFilter
+import com.kotcrab.vis.ui.widget.file.StreamingFileChooserListener
+import ksl.animation.util.parseAnimationToJson
 import ksl.animation.viewer.AnimationViewerScreen
 import ktx.actors.onClick
 import ktx.app.KtxGame
@@ -18,16 +23,49 @@ import ktx.app.KtxScreen
 import ktx.app.clearScreen
 import ktx.scene2d.vis.menu
 import ktx.scene2d.vis.menuItem
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 class AnimationBuilderScreen(private val game: KtxGame<KtxScreen>) : KtxScreen, InputAdapter() {
     private val stage = Stage(ScreenViewport())
     private val objectSelector = ObjectSelectorWindow({ type -> animationBuilder.addObject(type) })
     private val objectEditor = ObjectEditorWindow()
     private val fileChooser = FileChooser(FileChooser.Mode.OPEN)
+    private val saveFileChooser = FileChooser(FileChooser.Mode.SAVE)
     private var animationBuilder = AnimationBuilder({ renderable -> objectEditor.showObject(renderable) })
     private var controlPressed = false
     //Test
 
+    companion object {
+        data class SaveInfo(val pathStr: String, val simFileStr: String)
+    }
+    private var saveInfo: SaveInfo? = null
+
+    private fun saveAnimation(saveInfo: SaveInfo) {
+        val serializedJson = animationBuilder.serialize()
+
+        try {
+            val zipOut = ZipOutputStream(FileOutputStream(saveInfo.pathStr))
+
+            val setupJson = ZipEntry("setup.json")
+            zipOut.putNextEntry(setupJson)
+            val setupJsonData = parseAnimationToJson(serializedJson).encodeToByteArray()
+            zipOut.write(setupJsonData)
+            zipOut.closeEntry()
+
+            val simFile = ZipEntry("sim.log")
+            zipOut.putNextEntry(simFile)
+            val simFileData = saveInfo.simFileStr.encodeToByteArray()
+            zipOut.write(simFileData)
+            zipOut.closeEntry()
+
+            zipOut.close()
+        } catch (e: Exception) {
+            println(e.printStackTrace())
+            println("Invalid file!")
+        }
+    }
     override fun show() {
         val input = InputMultiplexer()
         input.addProcessor(stage)
@@ -51,6 +89,35 @@ class AnimationBuilderScreen(private val game: KtxGame<KtxScreen>) : KtxScreen, 
         importItem.onClick {
             this@AnimationBuilderScreen.stage.addActor(fileChooser.fadeIn())
         }
+
+        val saveItem = fileMenu.menuItem("Save...")
+        saveItem.setShortcut(Input.Keys.CONTROL_LEFT, Input.Keys.S)
+        saveItem.onClick {
+            val tmpInfo = saveInfo
+            if (tmpInfo == null) {
+                this@AnimationBuilderScreen.stage.addActor(saveFileChooser.fadeIn())
+            } else {
+                saveAnimation(tmpInfo)
+            }
+        }
+
+        // setup file chooser
+        saveFileChooser.selectionMode = FileChooser.SelectionMode.FILES
+        saveFileChooser.isFavoriteFolderButtonVisible = true
+        saveFileChooser.isShowSelectionCheckboxes = true
+        saveFileChooser.iconProvider = DefaultFileIconProvider(fileChooser)
+
+        val typeFilter = FileTypeFilter(true)
+        typeFilter.addRule("Animation file (*.anim, *.zip)", "anim", "zip")
+        saveFileChooser.setFileTypeFilter(typeFilter)
+
+        saveFileChooser.setListener(object : StreamingFileChooserListener() {
+            override fun selected(file: FileHandle) {
+                val tmpInfo = SaveInfo(file.path(), "")
+                saveInfo = tmpInfo
+                saveAnimation(tmpInfo)
+            }
+        })
 
         val editMenu = menuBar.menu("Edit")
         val undoItem = editMenu.menuItem("Undo...")

--- a/core/src/main/kotlin/ksl/animation/builder/AnimationBuilderScreen.kt
+++ b/core/src/main/kotlin/ksl/animation/builder/AnimationBuilderScreen.kt
@@ -45,6 +45,7 @@ class AnimationBuilderScreen(private val game: KtxGame<KtxScreen>) : KtxScreen, 
 
     private fun resetBuilder() {
         this.animationBuilder.resetScene()
+        this.saveInfo = null
     }
     private fun saveAnimation(saveInfo: SaveInfo) {
         val serializedJson = animationBuilder.serialize()

--- a/core/src/main/kotlin/ksl/animation/builder/AnimationBuilderScreen.kt
+++ b/core/src/main/kotlin/ksl/animation/builder/AnimationBuilderScreen.kt
@@ -13,6 +13,7 @@ import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.file.FileChooser
 import com.kotcrab.vis.ui.widget.file.FileChooser.DefaultFileIconProvider
+import com.kotcrab.vis.ui.widget.file.FileChooserAdapter
 import com.kotcrab.vis.ui.widget.file.FileTypeFilter
 import com.kotcrab.vis.ui.widget.file.StreamingFileChooserListener
 import ksl.animation.util.parseAnimationToJson
@@ -42,6 +43,9 @@ class AnimationBuilderScreen(private val game: KtxGame<KtxScreen>) : KtxScreen, 
     }
     private var saveInfo: SaveInfo? = null
 
+    private fun resetBuilder() {
+        this.animationBuilder.resetScene()
+    }
     private fun saveAnimation(saveInfo: SaveInfo) {
         val serializedJson = animationBuilder.serialize()
 
@@ -85,6 +89,10 @@ class AnimationBuilderScreen(private val game: KtxGame<KtxScreen>) : KtxScreen, 
         root.add().expand().fill()
 
         val fileMenu = menuBar.menu("File")
+        val newItem = fileMenu.menuItem("New File...")
+        newItem.onClick {
+            resetBuilder()
+        }
         val importItem = fileMenu.menuItem("Import...")
         importItem.onClick {
             this@AnimationBuilderScreen.stage.addActor(fileChooser.fadeIn())
@@ -116,6 +124,11 @@ class AnimationBuilderScreen(private val game: KtxGame<KtxScreen>) : KtxScreen, 
                 val tmpInfo = SaveInfo(file.path(), "")
                 saveInfo = tmpInfo
                 saveAnimation(tmpInfo)
+            }
+        })
+        saveFileChooser.setListener(object: FileChooserAdapter() {
+            override fun canceled() {
+                saveFileChooser.fadeOut()
             }
         })
 
@@ -193,6 +206,16 @@ class AnimationBuilderScreen(private val game: KtxGame<KtxScreen>) : KtxScreen, 
         if (keycode == Input.Keys.Y) {
             animationBuilder.selectedObject = ""
             animationBuilder.redo()
+            return true
+        }
+
+        if (keycode == Input.Keys.S) {
+            val tmpInfo = saveInfo
+            if (tmpInfo == null) {
+                this@AnimationBuilderScreen.stage.addActor(saveFileChooser.fadeIn())
+            } else {
+                saveAnimation(tmpInfo)
+            }
             return true
         }
 

--- a/core/src/main/kotlin/ksl/animation/builder/ObjectEditorWindow.kt
+++ b/core/src/main/kotlin/ksl/animation/builder/ObjectEditorWindow.kt
@@ -1,6 +1,7 @@
 package ksl.animation.builder
 
 import com.badlogic.gdx.math.Interpolation
+import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.utils.Align
@@ -27,9 +28,9 @@ class ObjectEditorWindow : VisWindow("Object Editor") {
         pack()
     }
 
-    fun showObject(kslObject: KSLRenderable?) {
+    fun showObject(kslObject: KSLRenderable?, stage: Stage) {
         content.clear()
-        kslObject?.displaySettings(content)
+        kslObject?.displaySettings(content, stage)
         pack()
     }
 

--- a/core/src/main/kotlin/ksl/animation/common/AnimationScene.kt
+++ b/core/src/main/kotlin/ksl/animation/common/AnimationScene.kt
@@ -90,6 +90,20 @@ open class AnimationScene {
 
         return KSLAnimation(objectList)
     }
+    open fun resetScene() {
+        this.images.clear()
+
+        this.objectTypes.clear()
+        this.objects.clear()
+        this.queues.clear()
+        this.resources.clear()
+        this.stations.clear()
+        this.variables.clear()
+        this.renderables.clear()
+
+        changePointer = 0
+        canRedo = false
+    }
 
     fun worldToScreen(position: Position): Position {
         return (position * screenUnit) + offset

--- a/core/src/main/kotlin/ksl/animation/common/renderables/KSLQueue.kt
+++ b/core/src/main/kotlin/ksl/animation/common/renderables/KSLQueue.kt
@@ -2,6 +2,7 @@ package ksl.animation.common.renderables
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
+import com.badlogic.gdx.scenes.scene2d.Stage
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextField
@@ -51,7 +52,7 @@ class KSLQueue(id: String, var startPosition: Position, var endPosition: Positio
         kslObject.inQueue = false
     }
 
-    override fun displaySettings(content: VisTable) {
+    override fun displaySettings(content: VisTable, stage: Stage) {
         val queueIdTextField = VisTextField(id)
         queueIdTextField.onChange { id = queueIdTextField.text }
 
@@ -64,7 +65,7 @@ class KSLQueue(id: String, var startPosition: Position, var endPosition: Positio
         content.row()
         content.add(spinner)
         content.pack()
-        super.displaySettings(content)
+        super.displaySettings(content, stage)
     }
 
     override fun pointInside(scene: AnimationScene, point: Position): Boolean {

--- a/core/src/main/kotlin/ksl/animation/common/renderables/KSLRenderable.kt
+++ b/core/src/main/kotlin/ksl/animation/common/renderables/KSLRenderable.kt
@@ -1,6 +1,7 @@
 package ksl.animation.common.renderables
 
 import com.badlogic.gdx.graphics.g2d.GlyphLayout
+import com.badlogic.gdx.scenes.scene2d.Stage
 import com.kotcrab.vis.ui.widget.VisTable
 import ksl.animation.Main
 import ksl.animation.common.AnimationScene
@@ -11,7 +12,7 @@ open class KSLRenderable(var id: String, var position: Position) {
     var highlighted = false
     var selected = false
 
-    open fun displaySettings(content: VisTable) {}
+    open fun displaySettings(content: VisTable, stage: Stage) {}
 
     open fun pointInside(scene: AnimationScene, point: Position): Boolean {
         return false

--- a/core/src/main/kotlin/ksl/animation/common/renderables/KSLVariable.kt
+++ b/core/src/main/kotlin/ksl/animation/common/renderables/KSLVariable.kt
@@ -4,9 +4,15 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.GlyphLayout
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
+import com.kotcrab.vis.ui.widget.VisTextButton
 import com.kotcrab.vis.ui.widget.VisTextField
+import com.kotcrab.vis.ui.widget.color.ColorPicker
+import com.kotcrab.vis.ui.widget.color.ColorPickerAdapter
 import com.kotcrab.vis.ui.widget.spinner.SimpleFloatSpinnerModel
 import com.kotcrab.vis.ui.widget.spinner.Spinner
 import ksl.animation.builder.changes.MoveAndResizeVariableChange
@@ -68,7 +74,7 @@ class KSLVariable(
             "#" + colorNum.toString(16)
         )
     }
-    override fun displaySettings(content: VisTable) {
+    override fun displaySettings(content: VisTable, stage: Stage) {
         val variableIdTextField = VisTextField(id)
         variableIdTextField.onChange { id = variableIdTextField.text }
         content.add(VisLabel("Variable ID "))
@@ -102,23 +108,23 @@ class KSLVariable(
         content.add(precisionSpinner)
 
         content.row()
-        val redSpeed = SimpleFloatSpinnerModel(round(this.textColor.r*255f), 0f, 255f, 1f)
-        val redSpinner = Spinner("Red", redSpeed)
-        redSpinner.onChange { textColor.r = redSpeed.value/255f }
-        content.add(redSpinner)
+        val variableColorButton = VisTextButton("Variable Color")
+        content.add(variableColorButton)
+        variableColorButton.addListener(object: ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                val colorPicker = ColorPicker("Variable Color", object : ColorPickerAdapter() {
+                    override fun finished(color: Color) {
+                        textColor = color
+                    }
+                })
 
-        val greenSpeed = SimpleFloatSpinnerModel(round(this.textColor.g*255f), 0f, 255f, 1f)
-        val greenSpinner = Spinner("Green", greenSpeed)
-        greenSpinner.onChange { textColor.g = greenSpeed.value/255f }
-        content.add(greenSpinner)
-
-        val blueSpeed = SimpleFloatSpinnerModel(round(this.textColor.b*255f), 0f, 255f, 1f)
-        val blueSpinner = Spinner("Blue", blueSpeed)
-        blueSpinner.onChange { textColor.b = blueSpeed.value/255f }
-        content.add(blueSpinner)
+                colorPicker.color = textColor
+                stage.addActor(colorPicker)
+            }
+        })
 
         content.pack()
-        super.displaySettings(content)
+        super.displaySettings(content, stage)
     }
     private enum class DragPoint(val value: Int) {
         TOP(1),

--- a/core/src/main/kotlin/ksl/animation/util/SerializableClasses.kt
+++ b/core/src/main/kotlin/ksl/animation/util/SerializableClasses.kt
@@ -42,3 +42,23 @@ fun parseJsonToAnimation(content: String): KSLAnimation {
 
     return json.decodeFromString<KSLAnimation>(content)
 }
+
+@OptIn(ExperimentalSerializationApi::class)
+fun parseAnimationToJson(content: KSLAnimation): String {
+    val json = Json {
+        namingStrategy = JsonNamingStrategy.SnakeCase
+        serializersModule = SerializersModule {
+            polymorphic(KSLAnimationObject::class) {
+                subclass(KSLAnimationObject.Image::class, KSLAnimationObject.Image.serializer())
+                subclass(KSLAnimationObject.Queue::class, KSLAnimationObject.Queue.serializer())
+                subclass(KSLAnimationObject.Resource::class, KSLAnimationObject.Resource.serializer())
+                subclass(KSLAnimationObject.ObjectType::class, KSLAnimationObject.ObjectType.serializer())
+                subclass(KSLAnimationObject.Object::class, KSLAnimationObject.Object.serializer())
+                subclass(KSLAnimationObject.Station::class, KSLAnimationObject.Station.serializer())
+            }
+        }
+        prettyPrint = true
+    }
+
+    return json.encodeToString<KSLAnimation>(content)
+}


### PR DESCRIPTION
* I added a save button using the serialization code I pushed in the last pull request. It seems to work fine, though I can't fully test it until the equivalent import stuff is setup.
* Added a "new" button that simply resets the builder scene
* Replaced 0-255 RGB values in the variable object editor in favor of opening a color picker.
  * One thing to note, I needed access to stage to open the color picker menu, so I made it part of the function chain. I can revoke this change if it ends up being too much of an issue though.